### PR TITLE
Add environment variable to github action 

### DIFF
--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -30,4 +30,4 @@ jobs:
          body: Build of skyline-rs-template from master.
          prerelease: true
          recreate: true
-         assets: ./target/aarch64-skyline-switch/release/$PLUGIN_NAME:$PLUGIN_NAME:application/octet-stream
+         assets: ./target/aarch64-skyline-switch/release/${{env.PLUGIN_NAME}}:${{env.PLUGIN_NAME}}:application/octet-stream

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -19,9 +19,7 @@ jobs:
       run: PATH=$PATH:/usr/share/rust/.rustup/toolchains/nightly-2020-04-10-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin cargo skyline build --release
       
 # uncomment the build step below to build on every change to master.
-    - name: set environment variables
-      uses: allenevans/set-env@v1.0.0
-      with:
+    - env:
           PLUGIN_NAME: 'libskyline_rs_template.nro'  #  change this to the name of your plugin
     - name: Upload Release
       uses: majkrzak/create-release@latest
@@ -32,4 +30,4 @@ jobs:
          body: Build of skyline-rs-template from master.
          prerelease: true
          recreate: true
-         assets: ./target/aarch64-skyline-switch/release/:${{PLUGIN_NAME}}:application/octet-stream
+         assets: ./target/aarch64-skyline-switch/release/$PLUGIN_NAME:$PLUGIN_NAME:application/octet-stream

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -19,10 +19,10 @@ jobs:
       run: PATH=$PATH:/usr/share/rust/.rustup/toolchains/nightly-2020-04-10-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin cargo skyline build --release
       
 # uncomment the build step below to build on every change to master.
-    - env:
-          PLUGIN_NAME: 'libskyline_rs_template.nro'  #  change this to the name of your plugin
     - name: Upload Release
       uses: majkrzak/create-release@latest
+      env:
+          PLUGIN_NAME: 'libskyline_rs_template.nro'  #  change this to the name of your plugin
       with:
          token: ${{ secrets.GITHUB_TOKEN }}
          name: master

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -32,4 +32,4 @@ jobs:
          body: Build of skyline-rs-template from master.
          prerelease: true
          recreate: true
-         assets: ./target/aarch64-skyline-switch/release/${PLUGIN_NAME}:${PLUGIN_NAME}:application/octet-stream
+         assets: ./target/aarch64-skyline-switch/release/:${{PLUGIN_NAME}}:application/octet-stream

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -19,15 +19,15 @@ jobs:
       run: PATH=$PATH:/usr/share/rust/.rustup/toolchains/nightly-2020-04-10-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin cargo skyline build --release
       
 # uncomment the build step below to build on every change to master.
-    - name: Upload Release
-      uses: majkrzak/create-release@latest
-      env:
-          PLUGIN_NAME: 'libskyline_rs_template.nro'  #  change this to the name of your plugin
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         name: master
-         code: master
-         body: Build of skyline-rs-template from master.
-         prerelease: true
-         recreate: true
-         assets: ./target/aarch64-skyline-switch/release/${{env.PLUGIN_NAME}}:${{env.PLUGIN_NAME}}:application/octet-stream
+#    - name: Upload Release
+#      uses: majkrzak/create-release@latest
+#      env:
+#          PLUGIN_NAME: 'libskyline_rs_template.nro'  #  change this to the name of your plugin
+#      with:
+#         token: ${{ secrets.GITHUB_TOKEN }}
+#         name: master
+#         code: master
+#         body: Build of skyline-rs-template from master.
+#         prerelease: true
+#         recreate: true
+#         assets: ./target/aarch64-skyline-switch/release/${{env.PLUGIN_NAME}}:${{env.PLUGIN_NAME}}:application/octet-stream

--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -17,18 +17,19 @@ jobs:
       run: cd .. && git clone https://github.com/jam1garner/rust-std-skyline-squashed && cd -
     - name: Attempt to build
       run: PATH=$PATH:/usr/share/rust/.rustup/toolchains/nightly-2020-04-10-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin cargo skyline build --release
-
+      
 # uncomment the build step below to build on every change to master.
-
-#     - name: Upload Release
-#       uses: majkrzak/create-release@latest
-#       with:
-#         token: ${{ secrets.GITHUB_TOKEN }}
-#         name: master
-#         code: master
-#         body: Build of skyline-rs-template from master.
-#         prerelease: true
-#         recreate: true
-#         assets: ./target/aarch64-skyline-switch/release/libskyline_rs_template.nro:libskyline_rs_template.nro:application/octet-stream
-  
-
+    - name: set environment variables
+      uses: allenevans/set-env@v1.0.0
+      with:
+          PLUGIN_NAME: 'libskyline_rs_template.nro'  #  change this to the name of your plugin
+    - name: Upload Release
+      uses: majkrzak/create-release@latest
+      with:
+         token: ${{ secrets.GITHUB_TOKEN }}
+         name: master
+         code: master
+         body: Build of skyline-rs-template from master.
+         prerelease: true
+         recreate: true
+         assets: ./target/aarch64-skyline-switch/release/${PLUGIN_NAME}:${PLUGIN_NAME}:application/octet-stream


### PR DESCRIPTION
Allows users to easily specify the name of their plugin to let the github action build/release it accordingly.