### PR TITLE
remove unnecessary line in mario's acmd

### DIFF
--- a/src/mario/mod.rs
+++ b/src/mario/mod.rs
@@ -11,7 +11,6 @@ use acmd::{acmd, acmd_func};
 pub fn mario_fair(fighter: &mut L2CFighterCommon) {
     acmd!({
         frame(16)
-        AttackModule::clear_all() // clear all previous hitboxes
         if(is_execute) {
             ATTACK(
                 ID=0, Part=0, Bone=hash40("arml"), 19.0, 361, 80, 0, 30, 113.0, 3.2, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0,


### PR DESCRIPTION
This clear_all before the hitbox was originally put in before ACMD funcs correctly overrode the vanilla ACMD scripts and that line was used to ensure that the custom ACMD would show. It is no longer necessary